### PR TITLE
Added BbCoreJS to Standard Edition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "symfony/filesystem": "~2.3",
         "incenteev/composer-parameter-handler": "2.1.0"
     },
     "autoload": {

--- a/src/ScriptHandler.php
+++ b/src/ScriptHandler.php
@@ -22,6 +22,7 @@
 namespace BackBee\Standard\Composer;
 
 use Composer\Script\CommandEvent;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -203,6 +204,31 @@ class ScriptHandler
         if (file_exists(self::parametersFilepath())) {
             unlink(self::parametersFilepath());
         }
+    }
+
+    /**
+     * Install Javascript client to ``repository/Resources/toolbar`` folder
+     */
+    public static function moveClient()
+    {
+        $filesystem = new Filesystem();
+        $filesystem->mirror(self::getVendorPath(), self::getToolbarPath());
+    }
+
+    /**
+     * path to BbCoreJS vendor
+     */
+    private static function getVendorPath()
+    {
+        return self::rootDir().DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'backbee'.DIRECTORY_SEPARATOR.'BbCoreJs';
+    }
+
+    /**
+     * path to Toolbar folder
+     */
+    private static function getToolbarPath()
+    {
+        return self::repositoryConfigDir().DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR .'toolbar'.DIRECTORY_SEPARATOR;
     }
 
     /**


### PR DESCRIPTION
As the standard edition is our version of the CMS with "our" Javascript client, I think it's better to:

* have a dependency on bbcore-js on backbee-standard repository
* dump the toolbar in the ``Resources`` folder of our application (or in a dedicated folder ?)

This way when we will have a bbcorejs standard edition, we just need to use ``composer update`` to update the full project, regardless this is PHP or Javascript stuff.

