### PR TITLE
Add permissive not found class content option

### DIFF
--- a/src/ScriptHandler.php
+++ b/src/ScriptHandler.php
@@ -117,6 +117,8 @@ class ScriptHandler
             $servicesConfig['parameters']['bbapp.data.dir'] = realpath($dataDir);
         }
 
+        $servicesConfig['parameters']['bbapp.classcontent.exception_on_unknown_classname'] = false;
+
         self::writeYamlFile(self::servicesFilepath(), $servicesConfig);
     }
 


### PR DESCRIPTION
Hi,
this option make the not found exception on class content silent by default in debug mode false.

This is useful when you create some class contents and then you update the name: the page is not broken anymore for the final users.

Of course, we need to update fixtures to delete GifDuJour class contents (again :/).

Regards,